### PR TITLE
招待一覧でステータスが表示されない

### DIFF
--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -497,6 +497,7 @@ class IndexController extends Controller
                 $invitations[$key]['invitation_url'] = $value->getInvitationUrl();
                 $invitations[$key]['envs'] = $value->getEnvs();
                 $invitations[$key]['expired_at'] = $value->getExpiredAt();
+                $invitations[$key]['status'] = $value->getStatus();
             }
             Log::info($invitations);
             // 整形済みの招待情報を返却


### PR DESCRIPTION
ユーザー招待一覧APIのレスポンスに status フィールドが含まれておらず、
フロントエンドの招待ステータス表示がされない不具合を修正