### PR TITLE
空のテナント属性値配列を適切な形式に変換する修正

### DIFF
--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -405,7 +405,8 @@ class IndexController extends Controller
             // テナントを作成
             $requestBody = new \stdClass();
             $requestBody->name = $tenantName;
-            $requestBody->attributes = $tenantAttributeValues;
+            // 空配列の場合は空オブジェクトに変換
+            $requestBody->attributes = empty($tenantAttributeValues) ? new \stdClass() : $tenantAttributeValues;
             $requestBody->back_office_staff_email = $email;
             $createdTenant = $authClient->createTenant($requestBody);
 


### PR DESCRIPTION
- `selfSignUp`メソッドで空のテナント属性値配列`[]`を空オブジェクト`{}`に変換する処理を追加
- テナント作成APIが空配列を受け入れない問題を解決

ユーザー属性[]で送られててエラーになる問題は下記で対応
https://github.com/saasus-platform/saasus-sdk-php/issues/33