### PR TITLE
認証エンドポイントの修正とリファクタリング

### DIFF
--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -24,6 +24,27 @@ class IndexController extends Controller
         $this->client = new \AntiPatternInc\Saasus\Api\Client();
     }
 
+    public function credentials(Request $request)
+    {
+        if (empty($request->code)) {
+            return response()->json('code is not provided by query parameter', Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $authClient = $this->client->getAuthClient();
+            $res = $authClient->getAuthCredentials([
+                'code' => $request->code,
+                'auth-flow' => 'tempCodeAuth',
+            ], $authClient::FETCH_RESPONSE);
+            
+            $body = json_decode($res->getBody(), true);
+            return response()->json($body, Response::HTTP_OK);
+        } catch (\Exception $e) {
+            Log::error($e->getMessage());
+            return response()->json(['detail' => 'Error occurred'], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
     public function refresh(Request $request)
     {
         // リフレッシュトークンを取得

--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -26,9 +26,9 @@ class IndexController extends Controller
 
     public function credentials(Request $request)
     {
-        if (empty($request->code)) {
-            return response()->json('code is not provided by query parameter', Response::HTTP_BAD_REQUEST);
-        }
+        $request->validate([
+            'code' => 'required|string'
+        ]);
 
         try {
             $authClient = $this->client->getAuthClient();
@@ -50,7 +50,7 @@ class IndexController extends Controller
         // リフレッシュトークンを取得
         $refreshToken = $request->cookie('SaaSusRefreshToken');
         if (!is_string($refreshToken)) {
-            return response('Refresh token not found', Response::HTTP_BAD_REQUEST);
+            return response()->json(['detail' => 'Refresh token not found'], Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -64,7 +64,7 @@ class IndexController extends Controller
             return response()->json($body, Response::HTTP_OK);
         } catch (\Exception $e) {
             Log::error($e->getMessage());
-            return response('Error occurred', Response::HTTP_INTERNAL_SERVER_ERROR);
+            return response()->json(['detail' => 'Error occurred'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -34,14 +34,15 @@ class IndexController extends Controller
 
         try {
             $authClient = $this->client->getAuthClient();
-            $response = $authClient->getAuthCredentials([
-                '',
-                'refreshTokenAuth',
-                $refreshToken
-            ]);
-
-            return response()->json($response->getBody());
+            $res = $authClient->getAuthCredentials([
+                'auth-flow' => 'refreshTokenAuth',
+                'refresh-token' => $refreshToken
+            ], $authClient::FETCH_RESPONSE);
+            
+            $body = json_decode($res->getBody(), true);
+            return response()->json($body, Response::HTTP_OK);
         } catch (\Exception $e) {
+            Log::error($e->getMessage());
             return response('Error occurred', Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\IndexController;
 use App\Http\Controllers\BillingController;
-use AntiPatternInc\Saasus\Laravel\Controllers\CallbackApiController;
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -16,8 +15,8 @@ use AntiPatternInc\Saasus\Laravel\Controllers\CallbackApiController;
 |
 */
 
-// 一時コードからIDトークンなどの認証情報を取得するコントローラを登録
-Route::get('/credentials', [CallbackApiController::class, 'index']);
+// 一時コードからIDトークンなどの認証情報を取得
+Route::get('/credentials', [IndexController::class, 'credentials']);
 Route::get('/refresh', [IndexController::class, 'refresh']);
 
 // SaaSus SDK標準のAuth Middlewareを利用する


### PR DESCRIPTION
## 変更内容
- `refresh`エンドポイントのバグ修正（連想配列とFETCH_RESPONSEを使用）
- `credentials`エンドポイントを`CallbackApiController`から`IndexController`に移行
- SDK標準コントローラーへの依存を削除