### PR TITLE
feat: MFAメール認証対応を追加

### DIFF
--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -578,7 +578,10 @@ class IndexController extends Controller
         try {
             $authClient = $this->client->getAuthClient();
             $mfaPref = $authClient->getUserMfaPreference($userInfo['id']);
-            return response()->json(['enabled' => $mfaPref->getEnabled()]);
+            return response()->json([
+                'enabled' => $mfaPref->getEnabled(),
+                'method' => $mfaPref->getMethod(),
+            ]);
         } catch (\Exception $e) {
             Log::error($e->getMessage());
             return response()->json(['detail' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
@@ -646,7 +649,7 @@ class IndexController extends Controller
         }
     }
 
-    // MFA有効化エンドポイント
+    // MFA有効化エンドポイント（認証アプリ）
     public function mfaEnable(Request $request)
     {
         $userInfo = $request->userinfo;
@@ -662,6 +665,28 @@ class IndexController extends Controller
             $authClient->updateUserMfaPreference($userInfo['id'], $requestBody);
 
             return response()->json(['message' => 'MFA has been enabled']);
+        } catch (\Exception $e) {
+            Log::error($e->getMessage());
+            return response()->json(['detail' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // MFAメール認証有効化エンドポイント
+    public function mfaEmailEnable(Request $request)
+    {
+        $userInfo = $request->userinfo;
+        if (!$userInfo) {
+            return response()->json(['detail' => 'No user'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $authClient = $this->client->getAuthClient();
+            $requestBody = new \stdClass();
+            $requestBody->enabled = true;
+            $requestBody->method = 'email';
+            $authClient->updateUserMfaPreference($userInfo['id'], $requestBody);
+
+            return response()->json(['message' => 'Email MFA has been enabled']);
         } catch (\Exception $e) {
             Log::error($e->getMessage());
             return response()->json(['detail' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,7 @@ Route::middleware(\AntiPatternInc\Saasus\Laravel\Middleware\Auth::class)->group(
     Route::get('/mfa_setup', [IndexController::class, 'mfaSetup']);
     Route::post('/mfa_verify', [IndexController::class, 'mfaVerify']);
     Route::post('/mfa_enable', [IndexController::class, 'mfaEnable']);
+    Route::post('/mfa_email_enable', [IndexController::class, 'mfaEmailEnable']);
     Route::post('/mfa_disable', [IndexController::class, 'mfaDisable']);
 
     /* --- Billing & Metering --- */


### PR DESCRIPTION
  ## 概要
  MFA認証方式にメール認証を追加し、フロントエンドの方式選択UIに対応するバックエンド改修です。
  
  ## 変更内容
  - `GET /mfa_status` レスポンスに `method` フィールドを追加
  - `POST /mfa_email_enable` エンドポイントを新規追加
  
  ## Related PRs
  - saasus-platform/implementation-sample-front-react#24 
