### PR TITLE
X-SaaSus-Trace-Id 自動引継機能の追加

### DIFF
--- a/app/Http/Controllers/BillingController.php
+++ b/app/Http/Controllers/BillingController.php
@@ -7,22 +7,18 @@ use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 /* ── SaaSus SDK ───────────────────────────────────────────── */
 use AntiPatternInc\Saasus\Api\Client  as SaasusClient;
-use AntiPatternInc\Saasus\Sdk\Auth\Client  as AuthClient;
-use AntiPatternInc\Saasus\Sdk\Pricing\Client  as PricingClient;
 use AntiPatternInc\Saasus\Sdk\Pricing\Model\UpdateMeteringUnitTimestampCountParam;
 use AntiPatternInc\Saasus\Sdk\Pricing\Model\UpdateMeteringUnitTimestampCountNowParam;
 use AntiPatternInc\Saasus\Sdk\Pricing\Model\PricingPlan;
 
 class BillingController extends Controller
 {
-  private AuthClient    $auth;
-  private PricingClient $pricing;
-
-  public function __construct()
+  private function createClient(Request $req): SaasusClient
   {
-    $client        = new SaasusClient();
-    $this->auth    = $client->getAuthClient();
-    $this->pricing = $client->getPricingClient();
+    $referer = $req->headers->get('referer', '');
+    $xSaasusReferer = $req->headers->get('x-saasus-referer', '');
+    $xSaasusTraceId = $req->headers->get('x-saasus-trace-id', '');
+    return new SaasusClient($referer, $xSaasusReferer, $xSaasusTraceId);
   }
 
 
@@ -55,13 +51,13 @@ class BillingController extends Controller
       }
 
       /* プラン情報取得 */
-      $plan = $this->pricing->getPricingPlan($planId);
+      $plan = $this->createClient($req)->getPricingClient()->getPricingPlan($planId);
       if (!$plan) {
         return response()->json(['detail' => 'Pricing plan not found for the given plan_id.'], Response::HTTP_NOT_FOUND);
       }
 
       /* 該当プラン履歴の tax_rate_id を取得 */
-      $tenant = $this->auth->getTenant($tenantId);
+      $tenant = $this->createClient($req)->getAuthClient()->getTenant($tenantId);
       if (!$tenant) {
         return response()->json(['detail' => 'Tenant not found for the given tenant_id.'], Response::HTTP_NOT_FOUND);
       }
@@ -84,7 +80,7 @@ class BillingController extends Controller
       // 該当税率情報
       $matchedTax = null;
       if ($matchedHistory && $matchedHistory['tax_id']) {
-        $allTaxRates = $this->pricing->getTaxRates();
+        $allTaxRates = $this->createClient($req)->getPricingClient()->getTaxRates();
         foreach ($allTaxRates->getTaxRates() as $taxRate) {
           if ($taxRate['id'] === $matchedHistory['tax_id']) {
             $matchedTax = $taxRate;
@@ -144,7 +140,7 @@ class BillingController extends Controller
       // =========================
       // 1) テナント情報取得
       // =========================
-      $tenant = $this->auth->getTenant($tenantId);
+      $tenant = $this->createClient($req)->getAuthClient()->getTenant($tenantId);
       $tz     = new \DateTimeZone('Asia/Tokyo');
 
       // ==============================================================
@@ -184,7 +180,7 @@ class BillingController extends Controller
         }
 
         /* プラン情報取得 */
-        $plan = $this->pricing->getPricingPlan($planId);
+        $plan = $this->createClient($req)->getPricingClient()->getPricingPlan($planId);
         if (!$plan) {
           return response()->json(['detail' => 'Pricing plan not found for the given plan_id.'], Response::HTTP_NOT_FOUND);
         }
@@ -295,7 +291,7 @@ class BillingController extends Controller
         ->setMethod($method)
         ->setCount($count);
 
-      $this->pricing->updateMeteringUnitTimestampCount(
+      $this->createClient($req)->getPricingClient()->updateMeteringUnitTimestampCount(
         $tenantId,
         $unit,
         $ts,
@@ -331,7 +327,7 @@ class BillingController extends Controller
         ->setMethod($method)
         ->setCount($count);
 
-      $this->pricing->updateMeteringUnitTimestampCountNow(
+      $this->createClient($req)->getPricingClient()->updateMeteringUnitTimestampCountNow(
         $tenantId,
         $unit,
         $param
@@ -448,7 +444,7 @@ class BillingController extends Controller
             $count = $usageCache[$unitName];
           } else {
             // メータリングユニットの使用量を取得
-            $resp = $this->pricing
+            $resp = $this->createClient($req)->getPricingClient()
               ->getMeteringUnitDateCountByTenantIdAndUnitNameAndDatePeriod(
                 $tenantId,
                 $unitName,
@@ -607,7 +603,7 @@ class BillingController extends Controller
   public function getPricingPlans(Request $req)
   {
     try {
-      $pricingPlansResponse = $this->pricing->getPricingPlans();
+      $pricingPlansResponse = $this->createClient($req)->getPricingClient()->getPricingPlans();
       return response()->json($pricingPlansResponse->getPricingPlans());
     } catch (\Throwable $e) {
       Log::error($e->getMessage());
@@ -621,7 +617,7 @@ class BillingController extends Controller
   public function getTaxRates(Request $req)
   {
     try {
-      $taxRatesResponse = $this->pricing->getTaxRates();
+      $taxRatesResponse = $this->createClient($req)->getPricingClient()->getTaxRates();
       return response()->json($taxRatesResponse->getTaxRates());
     } catch (\Throwable $e) {
       Log::error($e->getMessage());
@@ -644,7 +640,7 @@ class BillingController extends Controller
         return response()->json(['error' => 'Insufficient permissions'], Response::HTTP_FORBIDDEN);
       }
 
-      $tenant = $this->auth->getTenant($tenantId);
+      $tenant = $this->createClient($req)->getAuthClient()->getTenant($tenantId);
       if (!$tenant) {
         return response()->json(['error' => 'Tenant not found'], Response::HTTP_NOT_FOUND);
       }
@@ -722,7 +718,7 @@ class BillingController extends Controller
         $updateParam->using_next_plan_from = $usingNextPlanFrom;
       }
 
-      $this->auth->updateTenantPlan($tenantId, $updateParam);
+      $this->createClient($req)->getAuthClient()->updateTenantPlan($tenantId, $updateParam);
 
       return response()->json(['message' => 'Tenant plan updated successfully']);
     } catch (\Throwable $e) {

--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -17,11 +17,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class IndexController extends Controller
 {
-    private $client;
-
-    public function __construct()
+    private function createClient(Request $request): \AntiPatternInc\Saasus\Api\Client
     {
-        $this->client = new \AntiPatternInc\Saasus\Api\Client();
+        $referer = $request->headers->get('referer', '');
+        $xSaasusReferer = $request->headers->get('x-saasus-referer', '');
+        $xSaasusTraceId = $request->headers->get('x-saasus-trace-id', '');
+        return new \AntiPatternInc\Saasus\Api\Client($referer, $xSaasusReferer, $xSaasusTraceId);
     }
 
     public function refresh(Request $request)
@@ -33,7 +34,7 @@ class IndexController extends Controller
         }
 
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $response = $authClient->getAuthCredentials([
                 '',
                 'refreshTokenAuth',
@@ -67,7 +68,7 @@ class IndexController extends Controller
             return response()->json(['detail' => 'Invalid tenant ID'], Response::HTTP_BAD_REQUEST);
         }
 
-        $authClient = $this->client->getAuthClient();
+        $authClient = $this->createClient($request)->getAuthClient();
         $response = $authClient->getTenantUsers($tenantId);
         Log::info(json_encode($response));
         $users = [];
@@ -104,7 +105,7 @@ class IndexController extends Controller
         }
     
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $tenantAttributes = $authClient->getTenantAttributes();
             $tenantInfo = $authClient->getTenant($tenantId);
     
@@ -125,10 +126,10 @@ class IndexController extends Controller
         }
     }
 
-    public function userAttributes()
+    public function userAttributes(Request $request)
     {
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $res = $authClient->getUserAttributes();
             $attributes = array_map(function ($attribute) {
                 return [
@@ -174,7 +175,7 @@ class IndexController extends Controller
 
         try {
             // ユーザー属性情報を取得
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $userAttributesResponse = $authClient->getUserAttributes();
             $userAttributes = $userAttributesResponse->getUserAttributes();
             foreach ($userAttributes as $attribute) {
@@ -248,7 +249,7 @@ class IndexController extends Controller
 
         try {
             // SaaSusからユーザー情報を取得
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $deleteUser = $authClient->getTenantUser($tenantId, $userId);
 
             // テナントからユーザー情報を削除
@@ -326,7 +327,7 @@ class IndexController extends Controller
         }
 
         try {
-            $pricingClient = $this->client->getPricingClient();
+            $pricingClient = $this->createClient($request)->getPricingClient();
 
             $plan = $pricingClient->getPricingPlan($planId);
 
@@ -349,7 +350,7 @@ class IndexController extends Controller
         }
 
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $res = $authClient->getTenantAttributes();
             $attributes = array_map(function ($attribute) {
                 return [
@@ -385,7 +386,7 @@ class IndexController extends Controller
         }
 
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
 
             // テナント属性情報の取得
             $tenantAttributesResponse = $authClient->getTenantAttributes();
@@ -489,7 +490,7 @@ class IndexController extends Controller
 
         try {
             // 認証クライアントを初期化して招待一覧を取得
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $response = $authClient->getTenantInvitations($tenantId);
 
             $invitations = [];
@@ -554,7 +555,7 @@ class IndexController extends Controller
                 ->setEnvs([$createTenantInvitationParamEnvsItem]);
 
             // テナントへの招待を作成
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $authClient->createTenantInvitation(
                 $tenantId,
                 $createTenantInvitationParam
@@ -576,7 +577,7 @@ class IndexController extends Controller
         }
 
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $mfaPref = $authClient->getUserMfaPreference($userInfo['id']);
             return response()->json([
                 'enabled' => $mfaPref->getEnabled(),
@@ -602,7 +603,7 @@ class IndexController extends Controller
         }
 
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $param = new CreateSecretCodeParam();
             $param->setAccessToken($accessToken);
             $secretCode = $authClient->createSecretCode($userInfo['id'], $param);
@@ -636,7 +637,7 @@ class IndexController extends Controller
         }
 
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $param = new UpdateSoftwareTokenParam();
             $param->setAccessToken($accessToken);
             $param->setVerificationCode($verificationCode);
@@ -658,7 +659,7 @@ class IndexController extends Controller
         }
 
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $requestBody = new \stdClass();
             $requestBody->enabled = true;
             $requestBody->method = 'softwareToken';
@@ -680,7 +681,7 @@ class IndexController extends Controller
         }
 
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $requestBody = new \stdClass();
             $requestBody->enabled = true;
             $requestBody->method = 'email';
@@ -702,7 +703,7 @@ class IndexController extends Controller
         }
 
         try {
-            $authClient = $this->client->getAuthClient();
+            $authClient = $this->createClient($request)->getAuthClient();
             $requestBody = new \stdClass();
             $requestBody->enabled = false;
             $requestBody->method = 'softwareToken';

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
     'allowed_methods' => ['*'],
     'allowed_origins' => ['http://localhost:3000'],
     'allowed_origins_patterns' => [],
-    'allowed_headers' => ['Content-Type', 'X-Requested-With', 'Authorization', 'x-xsrf-token', 'X-Access-Token', 'x-saasus-referer'],
+    'allowed_headers' => ['Content-Type', 'X-Requested-With', 'Authorization', 'x-xsrf-token', 'X-Access-Token', 'x-saasus-referer', 'X-Saasus-Trace-Id'],
     'exposed_headers' => [],
     'max_age' => 0,
     'supports_credentials' => true,


### PR DESCRIPTION
  概要
  
  フロントエンドから送信される X-SaaSus-Trace-Id ヘッダーを受け取り、SaaSus SDK 経由の API
  リクエストに自動伝播する対応を追加しました。併せて、既存の referer / x-saasus-referer
  もコントローラー内のAPI呼び出しに伝播されるよう修正しています。
  
  変更内容
  
  config/cors.php
  
  - allowed_headers に X-Saasus-Trace-Id を追加
  
  app/Http/Controllers/IndexController.php
  
  - __construct() での引数なしクライアント生成を削除
  - createClient(Request $request) ヘルパーメソッドを追加（referer / x-saasus-referer / x-saasus-trace-id を渡す）
  - 全APIクライアント生成箇所をヘルパー経由に変更
  
  app/Http/Controllers/BillingController.php
  
  - 同上
  
  ローカルでの動作確認方法
  
  1. コンテナ内で composer update saasus-platform/saasus-sdk-php を実行
  
  マージ条件
  
  新しいsdkがリリースされたら
  
  1. コンテナ内で composer update saasus-platform/saasus-sdk-php を実行
  2. 更新された composer.lock をコミットに含める
